### PR TITLE
Better Round Function (Slightly breaking change)

### DIFF
--- a/Library.lua
+++ b/Library.lua
@@ -2084,11 +2084,11 @@ do
 
         local function Round(Value)
             if Slider.Rounding == 0 then
-                return math.floor(Value);
+                return Value - Value % 1;
             end;
 
-
-            return tonumber(string.format('%.' .. Slider.Rounding .. 'f', Value))
+            local Value = Value / Slider.Rounding;
+            return (Value - Value % 1) * Slider.Rounding;
         end;
 
         function Slider:GetValueFromXOffset(X)


### PR DESCRIPTION
Allows the user to round to the nearest `Slider.Rounding`, (ex: Rounds down to the nearest 0.2, 10, 200, 4000, etc)

It also doesn't encounter the math.round issue where there's a trailing epsilon, which can make the number appear ugly. (Such as 12.00000003)

You might want another config to account for this however, I don't think people loadstring past commits, which means they'll get the breaking changes immediately. I think all you need to do is modify the Slider.Rounding value based on the config and it will be all set.